### PR TITLE
Reduce screenshot size in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SimplePagedView is an iOS component that makes it as easy as possible to set up a page view for things like onboarding or presenting information.
 
-![simulator screen shot - iphone 8 - 2018-12-12 at 12 54 46](https://user-images.githubusercontent.com/5561501/49899079-87bbda80-fe0f-11e8-82ec-ea523e6cd42c.png)
+<img src="https://user-images.githubusercontent.com/5561501/49899079-87bbda80-fe0f-11e8-82ec-ea523e6cd42c.png" alt="simulator screen shot - iphone 8 - 2018-12-12 at 12 54 46" width=400 />
 
 ## Installation
 


### PR DESCRIPTION
Other notes
- Hosting the screenshot as part of `user-images.githubusercontent.com` isn't recommended, use the GitHub repo instead and reference it directly
- Screenshot has loading indicator visible
- Empty battery 😢